### PR TITLE
Fix image size so that Raspberry Pi Imager will write them.

### DIFF
--- a/make_e2fstools
+++ b/make_e2fstools
@@ -35,7 +35,7 @@ mkdir "$PACKAGES"
 mkdir "$TARGET"
 mkdir "$CMPL"
 
-download https://netix.dl.sourceforge.net/project/e2fsprogs/e2fsprogs/v1.44.0/e2fsprogs-1.44.0.tar.gz
+download https://netix.dl.sourceforge.net/project/e2fsprogs/e2fsprogs/v1.46.5/e2fsprogs-1.46.5.tar.gz
 cd e2fs*
 ./configure --prefix "$TARGET" --disable-nls
 make
@@ -43,7 +43,7 @@ cp -a e2fsck/e2fsck "$BASE"
 cp -a resize/resize2fs "$BASE"
 cp -a misc/tune2fs "$BASE"
 
-download https://ftp.gnu.org/gnu/coreutils/coreutils-8.29.tar.xz
+download https://ftp.gnu.org/gnu/coreutils/coreutils-9.1.tar.xz
 cd core*
 ./configure --prefix "$TARGET" --disable-nls
 make

--- a/pishrink
+++ b/pishrink
@@ -85,7 +85,6 @@ sleep 1
 
 #Truncate the file
 endresult=$(($newpartend * 512))
-endresult=$(($endresult + 1))
 truncate -s $endresult "$img"
 aftersize=$(ls -lh "$img" | tr -s " " | cut -d " " -f 5)
 


### PR DESCRIPTION
- Don't add one to size; Raspberry Pi Imager checks that image size is a multiple of 512.
- Update e2fsprogs and coreutils to latest versions.